### PR TITLE
Fixed an api request for the deprecated Twitch API 3

### DIFF
--- a/twitch.groovy
+++ b/twitch.groovy
@@ -172,11 +172,12 @@ class Twitch extends WebResourceUrlExtractor {
 	
 	List<WebResourceItem> extractHlsStream(String channelName) {
 		def items = [] // prepare list
-		
-		def auth = new JsonSlurper().parseText(new URL(String.format(TWITCH_ACCESSTOKEN_API, channelName.toLowerCase())).text)
+		def parser = new JsonSlurper()
+		def auth = parser.parseText(new URL(String.format(TWITCH_ACCESSTOKEN_API, channelName.toLowerCase())).text)
+		def channelId = parser.parseText(auth.token).channel_id
 		
 		//getting stream thubnail
-		def streamJson = new JsonSlurper().parseText(new URL(String.format(TWITCH_STREAM_API, channelName.toLowerCase())).text)
+		def streamJson = parser.parseText(new URL(String.format(TWITCH_STREAM_API, channelId)).text)
 		def thumbnailUrl
 		if (streamJson.stream) {
 			thumbnailUrl = streamJson.stream.preview.medium


### PR DESCRIPTION
I came across the issue that the plugin can not load channels info correctly(receives 400 http error) because support for **Twitch API v3** has ended and **Twitch API v5** has breaking changes - Streams API now requires a channel ID instead of channel name.
See "Username Versus User ID" section https://dev.twitch.tv/docs/v5/guides/migration/